### PR TITLE
Test improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
     - nightly
 
 matrix:

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,9 +2,9 @@
 
 namespace PUGX\Shortid\Test;
 
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use PUGX\Shortid\Factory;
+use RandomLib\Factory as RandomLibFactory;
 
 final class FactoryTest extends TestCase
 {
@@ -48,22 +48,18 @@ final class FactoryTest extends TestCase
     }
 
     /**
-     * @param string $alphabet
-     *
      * @dataProvider alphabetsProvider
      */
     public function testSetAlphabet(string $alphabet): void
     {
         $this->factory->setAlphabet($alphabet);
 
-        $newAlphabet = Assert::readAttribute($this->factory, 'alphabet');
+        $newAlphabet = $this->factory->getAlphabet();
 
         $this->assertSame($alphabet, $newAlphabet);
     }
 
     /**
-     * @param string $alphabet
-     *
      * @dataProvider wrongAlphabetsProvider
      */
     public function testSetWrongAlphabet(string $alphabet): void
@@ -88,7 +84,7 @@ final class FactoryTest extends TestCase
     {
         $factory = Factory::getFactory();
 
-        $this->assertInstanceOf('RandomLib\Factory', $factory);
+        $this->assertInstanceOf(RandomLibFactory::class, $factory);
     }
 
     public function testSetLength(): void

--- a/tests/ShortidTest.php
+++ b/tests/ShortidTest.php
@@ -2,6 +2,7 @@
 
 namespace PUGX\Shortid\Test;
 
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use PUGX\Shortid\Factory;
 use PUGX\Shortid\Shortid;
@@ -74,7 +75,7 @@ final class ShortidTest extends TestCase
     {
         $generated = Shortid::generate();
 
-        $this->assertInstanceOf('JsonSerializable', $generated);
+        $this->assertInstanceOf(JsonSerializable::class, $generated);
     }
 
     public function testJsonEncode(): void


### PR DESCRIPTION
# Changed log
- Removing the `php-7.4snapshot` version test, and using the `php-7.4` version instead on Travis CI build.
- According to the `Assert::readAttribute` is deprecated on `PHPUnit 8.2+` version, using the `Factory::getAlphabet` instead.
The reference is as available [here](https://github.com/sebastianbergmann/phpunit/issues/3338).